### PR TITLE
🧪 Mocking Draft

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,30 +153,6 @@ const { etherToWei } = require('essential-eth');
 arrayify(value: number | BytesLike | Hexable, options: DataOptions): Uint8Array
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { arrayify } from 'essential-eth';
-```
-
-```javascript
-arrayify(1);
-// Uint8Array(1) [ 1 ]
-```
-
-```javascript
-arrayify(0x1234);
-// Uint8Array(2) [ 18, 52 ]
-```
-
-```javascript
-arrayify('0x1', { hexPad: 'right' });
-// Uint8Array(1) [ 16 ]
-```
-
-  </details>
-
   <br/>
 
 #### [`computeAddress`](https://eeth.dev/docs/api/modules#computeaddress)
@@ -184,29 +160,6 @@ arrayify('0x1', { hexPad: 'right' });
 ```typescript
 computeAddress(key: string): string
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { computeAddress } from 'essential-eth';
-```
-
-```javascript
-computeAddress(
-  '0x0458eb591f407aef12936bd2989ca699cf5061de9c4964dd6eb6005fd8f580c407434447e813969a1be6e9954b002cad84dfc67a69e032b273e4695e7d0db2d952',
-); // public key
-// '0xA2902059a7BF992f1450BACD7357CCAa5cC8336a'
-```
-
-```javascript
-computeAddress(
-  '0x2f2c419acf4a1da8c1ebea75bb3fcfbd3ec2aa3bf0162901ccdc2f38b8f92427',
-); // private key
-// '0xA2902059a7BF992f1450BACD7357CCAa5cC8336a'
-```
-
-  </details>
 
   <br/>
 
@@ -216,30 +169,6 @@ computeAddress(
 computePublicKey(privKey: BytesLike): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { computePublicKey } from 'essential-eth';
-```
-
-```javascript
-computePublicKey(
-  '0xb27cc8dea0177d910110e8d3ec5480d56c723abf433529f4063f261ffdb9297c',
-);
-// '0x045cd0032015eecfde49f82f4e149d804e8ac6e3a0bface32e37c72a71ceac864fe84da7e8df84342f7b11dfb753c4d158f636142b46b29cf7f0f171ae0aa4fb87'
-```
-
-```javascript
-computePublicKey([
-  50, 102, 50, 99, 52, 49, 57, 97, 99, 102, 52, 97, 49, 100, 97, 56, 99, 49,
-  101, 98, 101, 97, 55, 53, 98, 98, 51, 102, 99, 102, 98, 100,
-]);
-// '0x04a9cea77eca949df84f661cee153426fb51f2294b9364b4fac240df57360b9b0ac9c99e4d7966491ab4c81f8c82e0cd24ec5759832ad4ab736d22c7d90b806ee8'
-```
-
-  </details>
-
   <br/>
 
 #### [`concat`](https://eeth.dev/docs/api/modules#concat)
@@ -247,20 +176,6 @@ computePublicKey([
 ```typescript
 concat(arrayOfBytesLike: Array<BytesLikeWithNumber>): Uint8Array
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { concat } from 'essential-eth';
-```
-
-```javascript
-concat([0, 1]);
-// Uint8Array(2) [ 0, 1 ]
-```
-
-  </details>
 
   <br/>
 
@@ -270,29 +185,6 @@ concat([0, 1]);
 etherToGwei(etherQuantity: string | number | TinyBig | Big): TinyBig
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { etherToGwei } from 'essential-eth';
-```
-
-```javascript
-etherToGwei('1000').toString();
-// '1000000000000'
-etherToGwei(1000).toString();
-// '1000000000000'
-```
-
-```javascript
-etherToGwei('1000').toNumber();
-// 1000000000000
-etherToGwei(1000).toNumber();
-// 1000000000000
-```
-
-  </details>
-
   <br/>
 
 #### [`etherToWei`](https://eeth.dev/docs/api/modules#ethertowei)
@@ -300,29 +192,6 @@ etherToGwei(1000).toNumber();
 ```typescript
 etherToWei(etherQuantity: string | number | TinyBig | Big): TinyBig
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { etherToWei } from 'essential-eth';
-```
-
-```javascript
-etherToWei('1000').toString();
-// '1000000000000000000000'
-etherToWei(1000).toString();
-// '1000000000000000000000'
-```
-
-```javascript
-etherToWei('1000').toNumber();
-// 1000000000000000000000
-etherToWei(1000).toNumber();
-// 1000000000000000000000
-```
-
-  </details>
 
   <br/>
 
@@ -332,29 +201,6 @@ etherToWei(1000).toNumber();
 gweiToEther(gweiQuantity: string | number | TinyBig | Big): TinyBig
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { gweiToEther } from 'essential-eth';
-```
-
-```javascript
-gweiToEther('1000000000000').toString();
-// '1000'
-gweiToEther(1000000000000).toString();
-// '1000'
-```
-
-```javascript
-gweiToEther('1000000000000').toNumber();
-// 1000
-gweiToEther(1000000000000).toNumber();
-// 1000
-```
-
-  </details>
-
   <br/>
 
 #### [`hashMessage`](https://eeth.dev/docs/api/modules#hashmessage)
@@ -362,20 +208,6 @@ gweiToEther(1000000000000).toNumber();
 ```typescript
 hashMessage(message: string | Bytes): string
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hashMessage } from 'essential-eth';
-```
-
-```javascript
-hashMessage('Hello World');
-// '0xa1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2'
-```
-
-  </details>
 
   <br/>
 
@@ -385,20 +217,6 @@ hashMessage('Hello World');
 hexConcat(items: Array<BytesLike>): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hexConcat } from 'essential-eth';
-```
-
-```javascript
-hexConcat([[2, 4, 0, 1], 9, '0x2934', '0x3947']);
-// '0x020400010929343947'
-```
-
-  </details>
-
   <br/>
 
 #### [`hexDataLength`](https://eeth.dev/docs/api/modules#hexdatalength)
@@ -406,25 +224,6 @@ hexConcat([[2, 4, 0, 1], 9, '0x2934', '0x3947']);
 ```typescript
 hexDataLength(data: BytesLike): undefined
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hexDataLength } from 'essential-eth';
-```
-
-```javascript
-hexDataLength([2, 4, 0, 1]);
-// 4
-```
-
-```javascript
-hexDataLength('0x3925');
-// 2
-```
-
-  </details>
 
   <br/>
 
@@ -434,20 +233,6 @@ hexDataLength('0x3925');
 hexDataSlice(data: BytesLikeWithNumber, offset: number, endOffset: number): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hexDataSlice } from 'essential-eth';
-```
-
-```javascript
-hexDataSlice([20, 6, 48], 0, 2);
-// '0x1406'
-```
-
-  </details>
-
   <br/>
 
 #### [`hexStripZeros`](https://eeth.dev/docs/api/modules#hexstripzeros)
@@ -455,20 +240,6 @@ hexDataSlice([20, 6, 48], 0, 2);
 ```typescript
 hexStripZeros(value: BytesLike): string
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hexStripZeros } from 'essential-eth';
-```
-
-```javascript
-hexStripZeros([0, 0, 0, 48]);
-// '0x30'
-```
-
-  </details>
 
   <br/>
 
@@ -478,25 +249,6 @@ hexStripZeros([0, 0, 0, 48]);
 hexValue(value: number | bigint | BytesLike | Hexable): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hexValue } from 'essential-eth';
-```
-
-```javascript
-hexValue(39);
-// '0x27'
-```
-
-```javascript
-hexValue([9, 4, 19, 4]);
-// '0x9041304'
-```
-
-  </details>
-
   <br/>
 
 #### [`hexZeroPad`](https://eeth.dev/docs/api/modules#hexzeropad)
@@ -504,30 +256,6 @@ hexValue([9, 4, 19, 4]);
 ```typescript
 hexZeroPad(value: BytesLikeWithNumber, length: number): string
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hexZeroPad } from 'essential-eth';
-```
-
-```javascript
-hexZeroPad('0x60', 2);
-// '0x0060'
-```
-
-```javascript
-hexZeroPad(0x60, 3);
-// '0x000060'
-```
-
-```javascript
-hexZeroPad('12345', 1);
-// Throws
-```
-
-  </details>
 
   <br/>
 
@@ -537,25 +265,6 @@ hexZeroPad('12345', 1);
 hexlify(value: number | bigint | BytesLike | Hexable, options: DataOptions): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { hexlify } from 'essential-eth';
-```
-
-```javascript
-hexlify(4);
-// '0x04'
-```
-
-```javascript
-hexlify(14);
-// '0x0e'
-```
-
-  </details>
-
   <br/>
 
 #### [`isAddress`](https://eeth.dev/docs/api/modules#isaddress)
@@ -563,31 +272,6 @@ hexlify(14);
 ```typescript
 isAddress(address: string): boolean
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { isAddress } from 'essential-eth';
-```
-
-```javascript
-isAddress('0xc0deaf6bd3f0c6574a6a625ef2f22f62a5150eab');
-// true
-```
-
-```javascript
-isAddress('bad');
-// false
-```
-
-```javascript
-// Does NOT support ENS.
-isAddress('vitalik.eth');
-// false
-```
-
-  </details>
 
   <br/>
 
@@ -597,30 +281,6 @@ isAddress('vitalik.eth');
 isBytes(value: any): value
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { isBytes } from 'essential-eth';
-```
-
-```javascript
-isBytes([1, 2, 3]);
-// true
-```
-
-```javascript
-isBytes(false);
-// false
-```
-
-```javascript
-isBytes(new Uint8Array(1));
-// true
-```
-
-  </details>
-
   <br/>
 
 #### [`isBytesLike`](https://eeth.dev/docs/api/modules#isbyteslike)
@@ -628,30 +288,6 @@ isBytes(new Uint8Array(1));
 ```typescript
 isBytesLike(value: any): value
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { isBytesLike } from 'essential-eth';
-```
-
-```javascript
-isBytesLike([1, 2, 3]);
-// true
-```
-
-```javascript
-isBytesLike(false);
-// false
-```
-
-```javascript
-isBytesLike(new Uint8Array(1));
-// true
-```
-
-  </details>
 
   <br/>
 
@@ -661,26 +297,6 @@ isBytesLike(new Uint8Array(1));
 isHexString(value: any, length: number): boolean
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { isHexString } from 'essential-eth';
-```
-
-```javascript
-isHexString('0x4924');
-// true
-```
-
-```javascript
-isHexString('0x4924', 4);
-// false
-// length of 4 in bytes would mean a hex string with 8 characters
-```
-
-  </details>
-
   <br/>
 
 #### [`jsonRpcProvider`](https://eeth.dev/docs/api/modules#jsonrpcprovider)
@@ -688,24 +304,6 @@ isHexString('0x4924', 4);
 ```typescript
 jsonRpcProvider(rpcUrl: string): JsonRpcProvider
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { jsonRpcProvider } from 'essential-eth';
-```
-
-```javascript
-jsonRpcProvider()
-  .getBlock('latest')
-  .then((block) => {
-    console.log(block.number);
-  });
-// 14530496
-```
-
-  </details>
 
   <br/>
 
@@ -715,23 +313,6 @@ jsonRpcProvider()
 keccak256(data: BytesLike): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { keccak256 } from 'essential-eth';
-```
-
-```javascript
-keccak256('essential-eth');
-// '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
-
-keccak256('0x123');
-// '0x5fa2358263196dbbf23d1ca7a509451f7a2f64c15837bfbb81298b1e3e24e4fa'
-```
-
-  </details>
-
   <br/>
 
 #### [`pack`](https://eeth.dev/docs/api/modules#pack)
@@ -739,22 +320,6 @@ keccak256('0x123');
 ```typescript
 pack(types: Array<string>, values: Array<any>): string
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { pack } from 'essential-eth';
-```
-
-```javascript
-const types = ['bool', 'string', 'uint64'];
-const values = [true, 'text', 30];
-pack(types, values);
-// '0x0174657874000000000000001e'
-```
-
-  </details>
 
   <br/>
 
@@ -764,32 +329,6 @@ pack(types, values);
 solidityKeccak256(types: Array<string>, values: Array<any>): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { solidityKeccak256 } from 'essential-eth';
-```
-
-```javascript
-const types = ['string', 'bool', 'uint32'];
-const values = ['essential-eth is great', true, 14];
-solidityKeccak256(types, values);
-// '0xe4d4c8e809faac09d58f468f0aeab9474fe8965d554c6c0f868c433c3fd6acab'
-```
-
-```javascript
-const types = ['bytes4', 'uint32[5]'];
-const values = [
-  [116, 101, 115, 116],
-  [5, 3, 4, 9, 18],
-];
-solidityKeccak256(types, values);
-// '0x038707a887f09355dc545412b058e7ba8f3c74047050c7c5e5e52eec608053d9'
-```
-
-  </details>
-
   <br/>
 
 #### [`splitSignature`](https://eeth.dev/docs/api/modules#splitsignature)
@@ -797,29 +336,6 @@ solidityKeccak256(types, values);
 ```typescript
 splitSignature(signature: SignatureLike): Signature
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { splitSignature } from 'essential-eth';
-```
-
-```javascript
-const signature = '0x60bc4ed91f2021aefe7045f3f77bd12f87eb733aee24bd1965343b3c27b3971647252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee331b';
-splitSignature(signature);
- {
-   r: "0x60bc4ed91f2021aefe7045f3f77bd12f87eb733aee24bd1965343b3c27b39716",
-   s: "0x47252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33",
-   _vs: "0x47252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33",
-   recoveryParam: 0,
-   v: 27,
-   yParityAndS: "0x47252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33",
-   compact: "0x60bc4ed91f2021aefe7045f3f77bd12f87eb733aee24bd1965343b3c27b3971647252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33"
- }
-```
-
-  </details>
 
   <br/>
 
@@ -829,21 +345,6 @@ splitSignature(signature);
 stripZeros(value: BytesLike): Uint8Array
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { stripZeros } from 'essential-eth';
-```
-
-```javascript
-stripZeros('0x00002834');
-// Uint8Array { [Iterator]  0: 40, 1: 52 }
-// Equivalent to '0x2834'
-```
-
-  </details>
-
   <br/>
 
 #### [`tinyBig`](https://eeth.dev/docs/api/modules#tinybig)
@@ -851,20 +352,6 @@ stripZeros('0x00002834');
 ```typescript
 tinyBig(value: string | number | TinyBig | Big): TinyBig
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { tinyBig } from 'essential-eth';
-```
-
-```javascript
-tinyBig(10).times(3).toNumber();
-// 30
-```
-
-  </details>
 
   <br/>
 
@@ -874,24 +361,6 @@ tinyBig(10).times(3).toNumber();
 toChecksumAddress(address: string): string
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { toChecksumAddress } from 'essential-eth';
-```
-
-```javascript
-toChecksumAddress('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359');
-// '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'
-```
-
-Similar to ["getAddress" in ethers.js](https://docs.ethers.io/v5/api/utils/address/#utils-getAddress)
-
-Similar to ["toChecksumAddress" in web3.js](https://web3js.readthedocs.io/en/v1.7.1/web3-utils.html#tochecksumaddress)
-
-  </details>
-
   <br/>
 
 #### [`toUtf8Bytes`](https://eeth.dev/docs/api/modules#toutf8bytes)
@@ -899,23 +368,6 @@ Similar to ["toChecksumAddress" in web3.js](https://web3js.readthedocs.io/en/v1.
 ```typescript
 toUtf8Bytes(data: string): Uint8Array
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { toUtf8Bytes } from 'essential-eth';
-```
-
-```javascript
-toUtf8Bytes('essential-eth');
-// Uint8Array { [Iterator] 0: 101, 1: 115, 2: 115, 3: 101, 4: 110, 5: 116, 6: 105, 7: 97, 8: 108, 9: 45, 10: 101, 11: 116, 12: 104 }
-
-toUtf8Bytes('ethereum');
-// Uint8Array { [Iterator]  0: 101, 1: 116, 2: 104, 3: 101, 4: 114, 5: 101, 6: 117, 7: 109 }
-```
-
-  </details>
 
   <br/>
 
@@ -925,29 +377,6 @@ toUtf8Bytes('ethereum');
 weiToEther(weiQuantity: string | number | TinyBig | Big): TinyBig
 ```
 
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { weiToEther } from 'essential-eth';
-```
-
-```javascript
-weiToEther('1000000000000000000000').toString();
-// '1000'
-weiToEther(1000000000000000000000).toString();
-// '1000'
-```
-
-```javascript
-weiToEther('1000000000000000000000').toNumber();
-// 1000
-weiToEther(1000000000000000000000).toNumber();
-// 1000
-```
-
-  </details>
-
   <br/>
 
 #### [`zeroPad`](https://eeth.dev/docs/api/modules#zeropad)
@@ -955,26 +384,6 @@ weiToEther(1000000000000000000000).toNumber();
 ```typescript
 zeroPad(value: BytesLike, length: number): Uint8Array
 ```
-
-  <details>
-  <summary>View Example</summary>
-
-```js
-import { zeroPad } from 'essential-eth';
-```
-
-```javascript
-zeroPad('0x039284');
-// Uint8Array { [Iterator]  0: 0, 1: 0, 2: 0, 3: 3, 4: 146, 5: 132 }
-// Equivalent to 0x000000039284
-```
-
-```javascript
-zeroPad([39, 25, 103, 45], 5);
-// Uint8Array { [Iterator]  0: 0, 1: 39, 2: 25, 3: 103, 4: 45 }
-```
-
-  </details>
 
   <br/>
 

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,30 @@ const { etherToWei } = require('essential-eth');
 arrayify(value: number | BytesLike | Hexable, options: DataOptions): Uint8Array
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { arrayify } from 'essential-eth';
+```
+
+```javascript
+arrayify(1);
+// Uint8Array(1) [ 1 ]
+```
+
+```javascript
+arrayify(0x1234);
+// Uint8Array(2) [ 18, 52 ]
+```
+
+```javascript
+arrayify('0x1', { hexPad: 'right' });
+// Uint8Array(1) [ 16 ]
+```
+
+  </details>
+
   <br/>
 
 #### [`computeAddress`](https://eeth.dev/docs/api/modules#computeaddress)
@@ -160,6 +184,29 @@ arrayify(value: number | BytesLike | Hexable, options: DataOptions): Uint8Array
 ```typescript
 computeAddress(key: string): string
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { computeAddress } from 'essential-eth';
+```
+
+```javascript
+computeAddress(
+  '0x0458eb591f407aef12936bd2989ca699cf5061de9c4964dd6eb6005fd8f580c407434447e813969a1be6e9954b002cad84dfc67a69e032b273e4695e7d0db2d952',
+); // public key
+// '0xA2902059a7BF992f1450BACD7357CCAa5cC8336a'
+```
+
+```javascript
+computeAddress(
+  '0x2f2c419acf4a1da8c1ebea75bb3fcfbd3ec2aa3bf0162901ccdc2f38b8f92427',
+); // private key
+// '0xA2902059a7BF992f1450BACD7357CCAa5cC8336a'
+```
+
+  </details>
 
   <br/>
 
@@ -169,6 +216,30 @@ computeAddress(key: string): string
 computePublicKey(privKey: BytesLike): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { computePublicKey } from 'essential-eth';
+```
+
+```javascript
+computePublicKey(
+  '0xb27cc8dea0177d910110e8d3ec5480d56c723abf433529f4063f261ffdb9297c',
+);
+// '0x045cd0032015eecfde49f82f4e149d804e8ac6e3a0bface32e37c72a71ceac864fe84da7e8df84342f7b11dfb753c4d158f636142b46b29cf7f0f171ae0aa4fb87'
+```
+
+```javascript
+computePublicKey([
+  50, 102, 50, 99, 52, 49, 57, 97, 99, 102, 52, 97, 49, 100, 97, 56, 99, 49,
+  101, 98, 101, 97, 55, 53, 98, 98, 51, 102, 99, 102, 98, 100,
+]);
+// '0x04a9cea77eca949df84f661cee153426fb51f2294b9364b4fac240df57360b9b0ac9c99e4d7966491ab4c81f8c82e0cd24ec5759832ad4ab736d22c7d90b806ee8'
+```
+
+  </details>
+
   <br/>
 
 #### [`concat`](https://eeth.dev/docs/api/modules#concat)
@@ -176,6 +247,20 @@ computePublicKey(privKey: BytesLike): string
 ```typescript
 concat(arrayOfBytesLike: Array<BytesLikeWithNumber>): Uint8Array
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { concat } from 'essential-eth';
+```
+
+```javascript
+concat([0, 1]);
+// Uint8Array(2) [ 0, 1 ]
+```
+
+  </details>
 
   <br/>
 
@@ -185,6 +270,29 @@ concat(arrayOfBytesLike: Array<BytesLikeWithNumber>): Uint8Array
 etherToGwei(etherQuantity: string | number | TinyBig | Big): TinyBig
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { etherToGwei } from 'essential-eth';
+```
+
+```javascript
+etherToGwei('1000').toString();
+// '1000000000000'
+etherToGwei(1000).toString();
+// '1000000000000'
+```
+
+```javascript
+etherToGwei('1000').toNumber();
+// 1000000000000
+etherToGwei(1000).toNumber();
+// 1000000000000
+```
+
+  </details>
+
   <br/>
 
 #### [`etherToWei`](https://eeth.dev/docs/api/modules#ethertowei)
@@ -192,6 +300,29 @@ etherToGwei(etherQuantity: string | number | TinyBig | Big): TinyBig
 ```typescript
 etherToWei(etherQuantity: string | number | TinyBig | Big): TinyBig
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { etherToWei } from 'essential-eth';
+```
+
+```javascript
+etherToWei('1000').toString();
+// '1000000000000000000000'
+etherToWei(1000).toString();
+// '1000000000000000000000'
+```
+
+```javascript
+etherToWei('1000').toNumber();
+// 1000000000000000000000
+etherToWei(1000).toNumber();
+// 1000000000000000000000
+```
+
+  </details>
 
   <br/>
 
@@ -201,6 +332,29 @@ etherToWei(etherQuantity: string | number | TinyBig | Big): TinyBig
 gweiToEther(gweiQuantity: string | number | TinyBig | Big): TinyBig
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { gweiToEther } from 'essential-eth';
+```
+
+```javascript
+gweiToEther('1000000000000').toString();
+// '1000'
+gweiToEther(1000000000000).toString();
+// '1000'
+```
+
+```javascript
+gweiToEther('1000000000000').toNumber();
+// 1000
+gweiToEther(1000000000000).toNumber();
+// 1000
+```
+
+  </details>
+
   <br/>
 
 #### [`hashMessage`](https://eeth.dev/docs/api/modules#hashmessage)
@@ -208,6 +362,20 @@ gweiToEther(gweiQuantity: string | number | TinyBig | Big): TinyBig
 ```typescript
 hashMessage(message: string | Bytes): string
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hashMessage } from 'essential-eth';
+```
+
+```javascript
+hashMessage('Hello World');
+// '0xa1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2'
+```
+
+  </details>
 
   <br/>
 
@@ -217,6 +385,20 @@ hashMessage(message: string | Bytes): string
 hexConcat(items: Array<BytesLike>): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hexConcat } from 'essential-eth';
+```
+
+```javascript
+hexConcat([[2, 4, 0, 1], 9, '0x2934', '0x3947']);
+// '0x020400010929343947'
+```
+
+  </details>
+
   <br/>
 
 #### [`hexDataLength`](https://eeth.dev/docs/api/modules#hexdatalength)
@@ -224,6 +406,25 @@ hexConcat(items: Array<BytesLike>): string
 ```typescript
 hexDataLength(data: BytesLike): undefined
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hexDataLength } from 'essential-eth';
+```
+
+```javascript
+hexDataLength([2, 4, 0, 1]);
+// 4
+```
+
+```javascript
+hexDataLength('0x3925');
+// 2
+```
+
+  </details>
 
   <br/>
 
@@ -233,6 +434,20 @@ hexDataLength(data: BytesLike): undefined
 hexDataSlice(data: BytesLikeWithNumber, offset: number, endOffset: number): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hexDataSlice } from 'essential-eth';
+```
+
+```javascript
+hexDataSlice([20, 6, 48], 0, 2);
+// '0x1406'
+```
+
+  </details>
+
   <br/>
 
 #### [`hexStripZeros`](https://eeth.dev/docs/api/modules#hexstripzeros)
@@ -240,6 +455,20 @@ hexDataSlice(data: BytesLikeWithNumber, offset: number, endOffset: number): stri
 ```typescript
 hexStripZeros(value: BytesLike): string
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hexStripZeros } from 'essential-eth';
+```
+
+```javascript
+hexStripZeros([0, 0, 0, 48]);
+// '0x30'
+```
+
+  </details>
 
   <br/>
 
@@ -249,6 +478,25 @@ hexStripZeros(value: BytesLike): string
 hexValue(value: number | bigint | BytesLike | Hexable): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hexValue } from 'essential-eth';
+```
+
+```javascript
+hexValue(39);
+// '0x27'
+```
+
+```javascript
+hexValue([9, 4, 19, 4]);
+// '0x9041304'
+```
+
+  </details>
+
   <br/>
 
 #### [`hexZeroPad`](https://eeth.dev/docs/api/modules#hexzeropad)
@@ -256,6 +504,30 @@ hexValue(value: number | bigint | BytesLike | Hexable): string
 ```typescript
 hexZeroPad(value: BytesLikeWithNumber, length: number): string
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hexZeroPad } from 'essential-eth';
+```
+
+```javascript
+hexZeroPad('0x60', 2);
+// '0x0060'
+```
+
+```javascript
+hexZeroPad(0x60, 3);
+// '0x000060'
+```
+
+```javascript
+hexZeroPad('12345', 1);
+// Throws
+```
+
+  </details>
 
   <br/>
 
@@ -265,6 +537,25 @@ hexZeroPad(value: BytesLikeWithNumber, length: number): string
 hexlify(value: number | bigint | BytesLike | Hexable, options: DataOptions): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { hexlify } from 'essential-eth';
+```
+
+```javascript
+hexlify(4);
+// '0x04'
+```
+
+```javascript
+hexlify(14);
+// '0x0e'
+```
+
+  </details>
+
   <br/>
 
 #### [`isAddress`](https://eeth.dev/docs/api/modules#isaddress)
@@ -272,6 +563,31 @@ hexlify(value: number | bigint | BytesLike | Hexable, options: DataOptions): str
 ```typescript
 isAddress(address: string): boolean
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { isAddress } from 'essential-eth';
+```
+
+```javascript
+isAddress('0xc0deaf6bd3f0c6574a6a625ef2f22f62a5150eab');
+// true
+```
+
+```javascript
+isAddress('bad');
+// false
+```
+
+```javascript
+// Does NOT support ENS.
+isAddress('vitalik.eth');
+// false
+```
+
+  </details>
 
   <br/>
 
@@ -281,6 +597,30 @@ isAddress(address: string): boolean
 isBytes(value: any): value
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { isBytes } from 'essential-eth';
+```
+
+```javascript
+isBytes([1, 2, 3]);
+// true
+```
+
+```javascript
+isBytes(false);
+// false
+```
+
+```javascript
+isBytes(new Uint8Array(1));
+// true
+```
+
+  </details>
+
   <br/>
 
 #### [`isBytesLike`](https://eeth.dev/docs/api/modules#isbyteslike)
@@ -288,6 +628,30 @@ isBytes(value: any): value
 ```typescript
 isBytesLike(value: any): value
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { isBytesLike } from 'essential-eth';
+```
+
+```javascript
+isBytesLike([1, 2, 3]);
+// true
+```
+
+```javascript
+isBytesLike(false);
+// false
+```
+
+```javascript
+isBytesLike(new Uint8Array(1));
+// true
+```
+
+  </details>
 
   <br/>
 
@@ -297,6 +661,26 @@ isBytesLike(value: any): value
 isHexString(value: any, length: number): boolean
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { isHexString } from 'essential-eth';
+```
+
+```javascript
+isHexString('0x4924');
+// true
+```
+
+```javascript
+isHexString('0x4924', 4);
+// false
+// length of 4 in bytes would mean a hex string with 8 characters
+```
+
+  </details>
+
   <br/>
 
 #### [`jsonRpcProvider`](https://eeth.dev/docs/api/modules#jsonrpcprovider)
@@ -304,6 +688,24 @@ isHexString(value: any, length: number): boolean
 ```typescript
 jsonRpcProvider(rpcUrl: string): JsonRpcProvider
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { jsonRpcProvider } from 'essential-eth';
+```
+
+```javascript
+jsonRpcProvider()
+  .getBlock('latest')
+  .then((block) => {
+    console.log(block.number);
+  });
+// 14530496
+```
+
+  </details>
 
   <br/>
 
@@ -313,6 +715,23 @@ jsonRpcProvider(rpcUrl: string): JsonRpcProvider
 keccak256(data: BytesLike): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { keccak256 } from 'essential-eth';
+```
+
+```javascript
+keccak256('essential-eth');
+// '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
+
+keccak256('0x123');
+// '0x5fa2358263196dbbf23d1ca7a509451f7a2f64c15837bfbb81298b1e3e24e4fa'
+```
+
+  </details>
+
   <br/>
 
 #### [`pack`](https://eeth.dev/docs/api/modules#pack)
@@ -320,6 +739,22 @@ keccak256(data: BytesLike): string
 ```typescript
 pack(types: Array<string>, values: Array<any>): string
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { pack } from 'essential-eth';
+```
+
+```javascript
+const types = ['bool', 'string', 'uint64'];
+const values = [true, 'text', 30];
+pack(types, values);
+// '0x0174657874000000000000001e'
+```
+
+  </details>
 
   <br/>
 
@@ -329,6 +764,32 @@ pack(types: Array<string>, values: Array<any>): string
 solidityKeccak256(types: Array<string>, values: Array<any>): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { solidityKeccak256 } from 'essential-eth';
+```
+
+```javascript
+const types = ['string', 'bool', 'uint32'];
+const values = ['essential-eth is great', true, 14];
+solidityKeccak256(types, values);
+// '0xe4d4c8e809faac09d58f468f0aeab9474fe8965d554c6c0f868c433c3fd6acab'
+```
+
+```javascript
+const types = ['bytes4', 'uint32[5]'];
+const values = [
+  [116, 101, 115, 116],
+  [5, 3, 4, 9, 18],
+];
+solidityKeccak256(types, values);
+// '0x038707a887f09355dc545412b058e7ba8f3c74047050c7c5e5e52eec608053d9'
+```
+
+  </details>
+
   <br/>
 
 #### [`splitSignature`](https://eeth.dev/docs/api/modules#splitsignature)
@@ -336,6 +797,29 @@ solidityKeccak256(types: Array<string>, values: Array<any>): string
 ```typescript
 splitSignature(signature: SignatureLike): Signature
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { splitSignature } from 'essential-eth';
+```
+
+```javascript
+const signature = '0x60bc4ed91f2021aefe7045f3f77bd12f87eb733aee24bd1965343b3c27b3971647252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee331b';
+splitSignature(signature);
+ {
+   r: "0x60bc4ed91f2021aefe7045f3f77bd12f87eb733aee24bd1965343b3c27b39716",
+   s: "0x47252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33",
+   _vs: "0x47252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33",
+   recoveryParam: 0,
+   v: 27,
+   yParityAndS: "0x47252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33",
+   compact: "0x60bc4ed91f2021aefe7045f3f77bd12f87eb733aee24bd1965343b3c27b3971647252185b7d2abb411b01b5d1ac4ab41ea486df1e9b396758c1aec6c1b6eee33"
+ }
+```
+
+  </details>
 
   <br/>
 
@@ -345,6 +829,21 @@ splitSignature(signature: SignatureLike): Signature
 stripZeros(value: BytesLike): Uint8Array
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { stripZeros } from 'essential-eth';
+```
+
+```javascript
+stripZeros('0x00002834');
+// Uint8Array { [Iterator]  0: 40, 1: 52 }
+// Equivalent to '0x2834'
+```
+
+  </details>
+
   <br/>
 
 #### [`tinyBig`](https://eeth.dev/docs/api/modules#tinybig)
@@ -352,6 +851,20 @@ stripZeros(value: BytesLike): Uint8Array
 ```typescript
 tinyBig(value: string | number | TinyBig | Big): TinyBig
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { tinyBig } from 'essential-eth';
+```
+
+```javascript
+tinyBig(10).times(3).toNumber();
+// 30
+```
+
+  </details>
 
   <br/>
 
@@ -361,6 +874,24 @@ tinyBig(value: string | number | TinyBig | Big): TinyBig
 toChecksumAddress(address: string): string
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { toChecksumAddress } from 'essential-eth';
+```
+
+```javascript
+toChecksumAddress('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359');
+// '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'
+```
+
+Similar to ["getAddress" in ethers.js](https://docs.ethers.io/v5/api/utils/address/#utils-getAddress)
+
+Similar to ["toChecksumAddress" in web3.js](https://web3js.readthedocs.io/en/v1.7.1/web3-utils.html#tochecksumaddress)
+
+  </details>
+
   <br/>
 
 #### [`toUtf8Bytes`](https://eeth.dev/docs/api/modules#toutf8bytes)
@@ -368,6 +899,23 @@ toChecksumAddress(address: string): string
 ```typescript
 toUtf8Bytes(data: string): Uint8Array
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { toUtf8Bytes } from 'essential-eth';
+```
+
+```javascript
+toUtf8Bytes('essential-eth');
+// Uint8Array { [Iterator] 0: 101, 1: 115, 2: 115, 3: 101, 4: 110, 5: 116, 6: 105, 7: 97, 8: 108, 9: 45, 10: 101, 11: 116, 12: 104 }
+
+toUtf8Bytes('ethereum');
+// Uint8Array { [Iterator]  0: 101, 1: 116, 2: 104, 3: 101, 4: 114, 5: 101, 6: 117, 7: 109 }
+```
+
+  </details>
 
   <br/>
 
@@ -377,6 +925,29 @@ toUtf8Bytes(data: string): Uint8Array
 weiToEther(weiQuantity: string | number | TinyBig | Big): TinyBig
 ```
 
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { weiToEther } from 'essential-eth';
+```
+
+```javascript
+weiToEther('1000000000000000000000').toString();
+// '1000'
+weiToEther(1000000000000000000000).toString();
+// '1000'
+```
+
+```javascript
+weiToEther('1000000000000000000000').toNumber();
+// 1000
+weiToEther(1000000000000000000000).toNumber();
+// 1000
+```
+
+  </details>
+
   <br/>
 
 #### [`zeroPad`](https://eeth.dev/docs/api/modules#zeropad)
@@ -384,6 +955,26 @@ weiToEther(weiQuantity: string | number | TinyBig | Big): TinyBig
 ```typescript
 zeroPad(value: BytesLike, length: number): Uint8Array
 ```
+
+  <details>
+  <summary>View Example</summary>
+
+```js
+import { zeroPad } from 'essential-eth';
+```
+
+```javascript
+zeroPad('0x039284');
+// Uint8Array { [Iterator]  0: 0, 1: 0, 2: 0, 3: 3, 4: 146, 5: 132 }
+// Equivalent to 0x000000039284
+```
+
+```javascript
+zeroPad([39, 25, 103, 45], 5);
+// Uint8Array { [Iterator]  0: 0, 1: 39, 2: 25, 3: 103, 4: 45 }
+```
+
+  </details>
 
   <br/>
 

--- a/src/providers/test/json-rpc-provider/call.test.ts
+++ b/src/providers/test/json-rpc-provider/call.test.ts
@@ -1,11 +1,15 @@
 import Big from 'big.js';
-import { ethers } from 'ethers';
-import Web3 from 'web3';
-import { JsonRpcProvider, tinyBig } from '../../..';
+import { JsonRpcProvider, TransactionRequest, tinyBig } from '../../..';
 import { hexToDecimal } from '../../../classes/utils/hex-to-decimal';
 import { rpcUrls } from './../rpc-urls';
+import * as unfetch from 'isomorphic-unfetch';
+import { mockOf } from '../mock-of';
+import { buildFetchInit, buildRPCPostBody } from '../../../classes/utils/fetchers';
+import { prepareTransaction } from '../../../classes/utils/prepare-transaction';
 
 const rpcUrl = rpcUrls.mainnet;
+
+jest.mock('isomorphic-unfetch');
 
 // Based on https://etherscan.io/tx/0x277c40de5bf1d4fa06e37dce8e1370dac7273a4b2a883515176f51abaa50d512
 const dataTo = {
@@ -29,8 +33,6 @@ const dataFromGasTo = {
 
 describe('provider.call', () => {
   const essentialEthProvider = new JsonRpcProvider(rpcUrl);
-  const web3Provider = new Web3(rpcUrl);
-  const ethersProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
 
   it('throws', async () => {
     await expect(
@@ -56,73 +58,52 @@ describe('provider.call', () => {
     ).rejects.toThrow();
   });
 
-  it('should match ethers.js -- data, to', async () => {
-    const [eeCall, ethersCall, web3Call] = await Promise.all([
-      essentialEthProvider.call(dataTo),
-      ethersProvider.call(dataTo),
-      web3Provider.eth.call(dataTo),
-    ]);
-    expect(eeCall).toBe(ethersCall);
-    expect(eeCall).toBe(web3Call);
+  async function testWithMockedResponse(data: TransactionRequest) {
+    // a sample Ethereum node response (hex string) expected from call() as a result of "executing" the transaction
+    const expectedResult = '0x0000000000000000000000000000000000000000000000000858898f93629000';
+    mockOf(unfetch.default).mockResolvedValueOnce({
+      text: () => Promise.resolve(JSON.stringify({ jsonrpc: '2.0', id: 1, result: expectedResult })),
+    } as Response);
+    
+    const spy = jest.spyOn(unfetch, 'default');
+
+    const eeCall = await essentialEthProvider.call(data);
+    expect(eeCall).toBe(expectedResult);
+
+    expect(spy).toHaveBeenCalledWith(
+      rpcUrl,
+      buildFetchInit(buildRPCPostBody('eth_call', [prepareTransaction(data), 'latest'])),
+    );
+  }
+
+  it('should return a valid response -- data, to', async () => {
+    await testWithMockedResponse(dataTo);
   });
 
-  it('should match ethers.js -- data, to, gasPrice', async () => {
+  it('should return a valid response -- data, to, gasPrice', async () => {
     const data = { ...dataTo, gasPrice: 99999999999 };
-    const [eeCall, ethersCall, web3Call] = await Promise.all([
-      essentialEthProvider.call(data),
-      ethersProvider.call(data),
-      web3Provider.eth.call(data),
-    ]);
-    expect(eeCall).toBe(ethersCall);
-    expect(eeCall).toBe(web3Call);
+    await testWithMockedResponse(data);
   });
 
-  it('should match ethers.js -- all mixed data as strings', async () => {
-    const [eeCall, ethersCall, web3Call] = await Promise.all([
-      essentialEthProvider.call(dataFromGasTo),
-      ethersProvider.call(dataFromGasTo),
-      web3Provider.eth.call({
-        ...dataFromGasTo,
-        nonce: Number(hexToDecimal(dataFromGasTo.nonce)),
-      }),
-    ]);
-    expect(eeCall).toBe(ethersCall);
-    expect(eeCall).toBe(web3Call);
+  it('should return a valid response -- all mixed data as strings', async () => {
+    await testWithMockedResponse(dataFromGasTo);
   });
 
-  it('should match ethers.js -- all mixed data as TinyBig', async () => {
-    const [eeCall, ethersCall, web3Call] = await Promise.all([
-      essentialEthProvider.call({
-        ...dataFromGasTo,
-        nonce: tinyBig(dataFromGasTo.nonce),
-        gas: tinyBig(dataFromGasTo.gas),
-        value: tinyBig(dataFromGasTo.value),
-      }),
-      ethersProvider.call(dataFromGasTo),
-      web3Provider.eth.call({
-        ...dataFromGasTo,
-        nonce: Number(hexToDecimal(dataFromGasTo.nonce)),
-      }),
-    ]);
-    expect(eeCall).toBe(ethersCall);
-    expect(eeCall).toBe(web3Call);
+  it('should return a valid response -- all mixed data as TinyBig', async () => {
+    await testWithMockedResponse({
+      ...dataFromGasTo,
+      nonce: tinyBig(dataFromGasTo.nonce),
+      gas: tinyBig(dataFromGasTo.gas),
+      value: tinyBig(dataFromGasTo.value),
+    });
   });
 
-  it('should match ethers.js -- all mixeddata as Big', async () => {
-    const [eeCall, ethersCall, web3Call] = await Promise.all([
-      essentialEthProvider.call({
-        ...dataFromGasTo,
-        nonce: new Big(hexToDecimal(dataFromGasTo.nonce)),
-        gas: new Big(dataFromGasTo.gas),
-        value: new Big(hexToDecimal(dataFromGasTo.value)),
-      }),
-      ethersProvider.call(dataFromGasTo),
-      web3Provider.eth.call({
-        ...dataFromGasTo,
-        nonce: Number(hexToDecimal(dataFromGasTo.nonce)),
-      }),
-    ]);
-    expect(eeCall).toBe(ethersCall);
-    expect(eeCall).toBe(web3Call);
+  it('should return a valid response -- all mixeddata as Big', async () => {
+    await testWithMockedResponse({
+      ...dataFromGasTo,
+      nonce: new Big(hexToDecimal(dataFromGasTo.nonce)),
+      gas: new Big(dataFromGasTo.gas),
+      value: new Big(hexToDecimal(dataFromGasTo.value)),
+    });
   });
 });

--- a/src/providers/test/json-rpc-provider/get-fee-data.test.ts
+++ b/src/providers/test/json-rpc-provider/get-fee-data.test.ts
@@ -3,6 +3,7 @@ import {
   buildFetchInit,
   buildRPCPostBody,
 } from '../../../classes/utils/fetchers';
+import type { TinyBig } from '../../../shared/tiny-big/tiny-big';
 import { JsonRpcProvider } from '../../JsonRpcProvider';
 import { mockOf } from '../mock-of';
 import { rpcUrls } from './../rpc-urls';
@@ -37,15 +38,17 @@ describe('provider.getFeeData', () => {
     } as Response);
     const spy = jest.spyOn(unfetch, 'default');
 
-    const feeData = await essentialEthProvider.getFeeData();
+    const feeData = (await essentialEthProvider.getFeeData()) as {
+      gasPrice: TinyBig;
+      lastBaseFeePerGas: TinyBig;
+      maxFeePerGas: TinyBig;
+      maxPriorityFeePerGas: TinyBig;
+    };
     expect(feeData.gasPrice.toString()).toBe('10');
-    // @ts-ignore
     // lastBaseFeePerGas should be equal to the mocked baseFeePerGas value
     expect(feeData.lastBaseFeePerGas.toString()).toBe('10');
-    // @ts-ignore
     // maxFeePerGas is calculated as (baseFeePerGas * 2) + maxPriorityFeePerGas, (10 * 2) + 1500000000 = 1500000020
     expect(feeData.maxFeePerGas.toString()).toBe('1500000020');
-    // @ts-ignore
     // maxPriorityFeePerGas is a constant value (1500000000) in the getFeeData function
     expect(feeData.maxPriorityFeePerGas.toString()).toBe('1500000000');
     expect(spy).toHaveBeenCalledWith(

--- a/src/providers/test/json-rpc-provider/get-fee-data.test.ts
+++ b/src/providers/test/json-rpc-provider/get-fee-data.test.ts
@@ -1,35 +1,62 @@
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import * as unfetch from 'isomorphic-unfetch';
+import {
+  buildFetchInit,
+  buildRPCPostBody,
+} from '../../../classes/utils/fetchers';
 import { JsonRpcProvider } from '../../JsonRpcProvider';
+import { mockOf } from '../mock-of';
 import { rpcUrls } from './../rpc-urls';
 
 const rpcUrl = rpcUrls.mainnet;
 
 const essentialEthProvider = new JsonRpcProvider(rpcUrl);
-const ethersProvider = new StaticJsonRpcProvider(rpcUrl);
+
+jest.mock('isomorphic-unfetch');
+//  essentialEthProvider.getFeeData() calls these methods internally
+const mockGetBlockResponse = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  result: {
+    baseFeePerGas: '0xa',
+    // add more block data here if needed
+  },
+});
+const mockGetGasPriceResponse = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  result: '0xa',
+});
+
 describe('provider.getFeeData', () => {
-  it('should match ethers.js', async () => {
-    const [ethersFeeData, eeFeeData] = await Promise.all([
-      ethersProvider.getFeeData(),
-      essentialEthProvider.getFeeData(),
-    ]);
-    expect(eeFeeData.gasPrice.toString()).toBe(
-      // @ts-ignore
-      ethersFeeData?.gasPrice.toString(),
-    );
+  it('should match mocked responses', async () => {
+    mockOf(unfetch.default).mockResolvedValueOnce({
+      text: () => Promise.resolve(mockGetBlockResponse),
+    } as Response);
+    mockOf(unfetch.default).mockResolvedValueOnce({
+      text: () => Promise.resolve(mockGetGasPriceResponse),
+    } as Response);
+    const spy = jest.spyOn(unfetch, 'default');
+
+    const feeData = await essentialEthProvider.getFeeData();
+    expect(feeData.gasPrice.toString()).toBe('10');
     // @ts-ignore
-    expect(eeFeeData.lastBaseFeePerGas.toString()).toBe(
-      // @ts-ignore
-      ethersFeeData?.lastBaseFeePerGas.toString(),
-    );
+    // lastBaseFeePerGas should be equal to the mocked baseFeePerGas value
+    expect(feeData.lastBaseFeePerGas.toString()).toBe('10');
     // @ts-ignore
-    expect(eeFeeData.maxFeePerGas.toString()).toBe(
-      // @ts-ignore
-      ethersFeeData?.maxFeePerGas.toString(),
-    );
+    // maxFeePerGas is calculated as (baseFeePerGas * 2) + maxPriorityFeePerGas, (10 * 2) + 1500000000 = 1500000020
+    expect(feeData.maxFeePerGas.toString()).toBe('1500000020');
     // @ts-ignore
-    expect(eeFeeData.maxPriorityFeePerGas.toString()).toBe(
-      // @ts-ignore
-      ethersFeeData?.maxPriorityFeePerGas.toString(),
+    // maxPriorityFeePerGas is a constant value (1500000000) in the getFeeData function
+    expect(feeData.maxPriorityFeePerGas.toString()).toBe('1500000000');
+    expect(spy).toHaveBeenCalledWith(
+      rpcUrl,
+      buildFetchInit(
+        buildRPCPostBody('eth_getBlockByNumber', ['latest', false]),
+      ),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      rpcUrl,
+      buildFetchInit(buildRPCPostBody('eth_gasPrice', [])),
     );
   });
 });

--- a/src/providers/test/json-rpc-provider/get-transaction.test.ts
+++ b/src/providers/test/json-rpc-provider/get-transaction.test.ts
@@ -1,68 +1,94 @@
-import { ethers } from 'ethers';
 import omit from 'just-omit';
-import Web3 from 'web3';
-import type web3core from 'web3-core';
 import { hexToDecimal } from '../../../classes/utils/hex-to-decimal';
 import { JsonRpcProvider, tinyBig } from '../../../index';
 import type { TransactionResponse } from '../../../types/Transaction.types';
 import { rpcUrls } from '../rpc-urls';
+import * as unfetch from 'isomorphic-unfetch';
+import { mockOf } from '../mock-of';
 
 const rpcUrl = rpcUrls.mainnet;
 
+jest.mock('isomorphic-unfetch');
+
+const transactionHash =
+      '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
+
+const mockTransactionResponse = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  result: {
+    blockHash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    blockNumber: '0x1',
+    from: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+    gas: '0x5208',
+    gasPrice: '0x2540be400',
+    hash: transactionHash,
+    input: '0x',
+    nonce: '0x1',
+    to: '0x3535353535353535353535353535353535353535',
+    transactionIndex: '0x0',
+    value: '0x1',
+    v: '0x25',
+    r: '0x3d71c9ac9e9382a652a96217c3ee7a4b4f75ec86d4c6a4ad5754a13c1eb14d19',
+    s: '0x7e0f08a62d7c1150238e2bc1b9d6d49fa6c1758c0f60e0d6646d30e7b6598a2e',
+  }
+});
+
+const mockBlockResponse = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  result: {
+    number: '0x3',
+    hash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    parentHash: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    mixHash: '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+    nonce: '0x0102030405060708',
+    sha3Uncles: '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+    logsBloom: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    transactionsRoot: '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+    stateRoot: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    receiptsRoot: '0x1111111111111111111111111111111111111111111111111111111111111111',
+    miner: '0x8888888888888888888888888888888888888888',
+    difficulty: '0x20000',
+    totalDifficulty: '0x30000',
+    extraData: '0x74657374',
+    size: '0x100',
+    gasLimit: '0x2fefd8',
+    gasUsed: '0x5208',
+    timestamp: '0x5f2e4f20',
+    transactions: [],
+    uncles: [],
+  }
+});
+
+// Web3 transaction response for the same hash
+const expectedTransactionResponse = {
+  blockHash: '0x876810a013dbcd140f6fd6048c1dc33abbb901f1f96b394c2fa63aef3cb40b5d',
+  blockNumber: 14578286,
+  from: '0xdfD9dE5f6FA60BD70636c0900752E93a6144AEd4',
+  gas: 112163,
+  gasPrice: '48592426858',
+  maxPriorityFeePerGas: '1500000000',
+  maxFeePerGas: '67681261618',
+  hash: '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789',
+  input: '0x83259f170000000000000000000000000000000000000000000000000000000000000080000000000000000000000000dfd9de5f6fa60bd70636c0900752e93a6144aed400000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000009e99ad11a214fd016b19dc3648678c5944859ae292b21c24ca94f857836c4596f1950c82dd0c23dd621af4763edc2f66466e63c5df9de0c1107b1cd16bf460fe93e43fd308e3444bc79c3d88a4cb961dc8367ab6ad048867afc76d193bca99cf3a068864ed4a7df1dbf1d4c52238eced3e5e05644b4040fc2b3ccb8557b0e99fff6131305a0ea2b8061b90bd418db5bbdd2e92129f52d93f90531465e309c4caec5b85285822b6196398d36f16f511811b61bbda6461e80e29210cd303118bdcee8df6fa0505ffbe8642094fd2ba4dd458496fe3b459ac880bbf71877c713e969ccf5ed7efab8a84ebc07e3939901371ca427e1192e455a8f35a6a1d7ad09e1475dd1758b36fa631dab5d70e99316b23c4c43094188d360cd9c3457355904e07c00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000162074a7047f',
+  nonce: 129,
+  to: '0x39B72d136ba3e4ceF35F48CD09587ffaB754DD8B',
+  transactionIndex: 29,
+  value: '0',
+  type: 2,
+  accessList: [],
+  chainId: '1',
+  v: '0x0',
+  r: '0x59a7c15b12c18cd68d6c440963d959bff3e73831ffc938e75ecad07f7ee43fbc',
+  s: '0x1ebaf05f0d9273b16c2a7748b150a79d22533a8cd74552611cbe620fee3dcf1c'
+}
+
 describe('provider.getTransaction', () => {
   function testTransactionEquality(
-    transaction1: ethers.providers.TransactionResponse | web3core.Transaction,
-    transaction2: TransactionResponse,
+    testTransaction: TransactionResponse,
   ) {
-    let numCheckKeys: Array<string> = [];
-    let omittable1: Array<string> = [];
-    let omittable2: Array<string> = [];
-    if ((transaction1 as ethers.providers.TransactionResponse).confirmations) {
-      // only the ethers response has confirmations
-      // requires manually comparing values via bigNum conversion
-      numCheckKeys = [
-        'nonce',
-        'value',
-        'gas',
-        'gasPrice',
-        'maxFeePerGas',
-        'maxPriorityFeePerGas',
-        'confirmations',
-      ];
-
-      omittable1 = [
-        'wait', // ethers injects this to allow you to wait on a certain confirmation count
-        'creates', // ethers injects this custom https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L336
-        'data', // ethers renames input to data https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L331
-        'gasLimit', // ethers renames gas to gasLimit https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L320
-        'input',
-        ...numCheckKeys,
-      ];
-
-      omittable2 = ['input', ...numCheckKeys];
-
-      numCheckKeys.forEach((key) => {
-        let ethersKey = key as keyof ethers.providers.TransactionResponse;
-        if (key === 'gas') {
-          ethersKey = 'gasLimit';
-        }
-        // give small room for error in tests
-        expect(
-          tinyBig((transaction1 as any)[ethersKey])
-            .minus(tinyBig((transaction2 as any)[key]))
-            .abs()
-            .lt(2),
-        ).toBe(true);
-      });
-
-      expect(
-        Math.abs(
-          (transaction1 as ethers.providers.TransactionResponse).confirmations -
-            transaction2.confirmations,
-        ),
-      ).toBeLessThan(3);
-    } else {
-      numCheckKeys = [
+      const numCheckKeys = [
         'chainId',
         'gas',
         'gasPrice',
@@ -72,54 +98,57 @@ describe('provider.getTransaction', () => {
         'v',
         'value',
       ];
-      omittable1 = [...numCheckKeys];
-      omittable2 = ['confirmations', ...numCheckKeys];
+      const omittable1 = [...numCheckKeys];
+      const omittable2 = ['confirmations', ...numCheckKeys];
 
       numCheckKeys.forEach((key) => {
+        console.log(key);
         if (
-          typeof (transaction1 as any)[key] === 'string' &&
-          (transaction1 as any)[key].startsWith('0x')
+          typeof (expectedTransactionResponse as any)[key] === 'string' &&
+          (expectedTransactionResponse as any)[key].startsWith('0x')
         ) {
-          (transaction1 as any)[key] = Number(
-            hexToDecimal((transaction1 as any)[key]),
+          (expectedTransactionResponse as any)[key] = Number(
+            hexToDecimal((expectedTransactionResponse as any)[key]),
           );
         }
         // give room for error in tests
         expect(
-          tinyBig((transaction1 as any)[key])
-            .minus(tinyBig((transaction2 as any)[key]))
+          tinyBig((expectedTransactionResponse as any)[key])
+            .minus(tinyBig((testTransaction as any)[key]))
             .abs()
             .lt(2),
         ).toBe(true);
       });
-    }
 
-    const omittedTransaction1 = omit(transaction1, omittable1 as any);
-    const omittedTransaction2 = omit(transaction2, omittable2 as any);
-    expect(omittedTransaction1).toMatchObject(omittedTransaction2);
+    const omittedexpectedTransactionResponse = omit(expectedTransactionResponse, omittable1 as any);
+    const omittedTransaction2 = omit(testTransaction, omittable2 as any);
+    expect(omittedexpectedTransactionResponse).toMatchObject(omittedTransaction2);
   }
+
   it('should match web3.js', async () => {
-    const transactionHash =
-      '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
-    const web3Provider = new Web3(rpcUrl);
     const essentialEthProvider = new JsonRpcProvider(rpcUrl);
-    const [web3Transaction, essentialEthTransaction] = await Promise.all([
-      web3Provider.eth.getTransaction(transactionHash),
-      essentialEthProvider.getTransaction(transactionHash),
-    ]);
+    mockOf(unfetch.default).mockResolvedValueOnce({
+      text: () => Promise.resolve(mockTransactionResponse),
+    } as Response);
+    mockOf(unfetch.default).mockResolvedValueOnce({
+      text: () => Promise.resolve(mockBlockResponse),
+    } as Response);
+    const spy = jest.spyOn(unfetch, 'default');
 
-    testTransactionEquality(web3Transaction, essentialEthTransaction);
+    const essentialEthTransaction = await essentialEthProvider.getTransaction( transactionHash );
+    console.log(essentialEthTransaction);
+    testTransactionEquality(essentialEthTransaction)
   });
-  it('should match ethers.js', async () => {
-    const transactionHash =
-      '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
-    const ethersProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
-    const essentialEthProvider = new JsonRpcProvider(rpcUrl);
-    const [ethersTransaction, essentialEthTransaction] = await Promise.all([
-      ethersProvider.getTransaction(transactionHash),
-      essentialEthProvider.getTransaction(transactionHash),
-    ]);
+  // it('should match ethers.js', async () => {
+  //   const transactionHash =
+  //     '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
+  //   const ethersProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
+  //   const essentialEthProvider = new JsonRpcProvider(rpcUrl);
+  //   const [ethersTransaction, essentialEthTransaction] = await Promise.all([
+  //     ethersProvider.getTransaction(transactionHash),
+  //     essentialEthProvider.getTransaction(transactionHash),
+  //   ]);
 
-    testTransactionEquality(ethersTransaction, essentialEthTransaction);
-  });
+  //   testTransactionEquality(ethersTransaction, essentialEthTransaction);
+  // });
 });


### PR DESCRIPTION
Hey @dawsbot, I have made some assumptions that I would like to ask you about: 

`call.test.ts`
For the response from call I choose a completely arbitrary hex string:
https://github.com/jtfirek/essential-eth/blob/ebfc4e633aff898b7b0bff0a66e8e234d3e3e125/src/providers/test/json-rpc-provider/call.test.ts#L63-L66

I am using the prepareTransaction function here to test the sky, but it feels weird using library functions in the test:
https://github.com/jtfirek/essential-eth/blob/ebfc4e633aff898b7b0bff0a66e8e234d3e3e125/src/providers/test/json-rpc-provider/call.test.ts#L75

`get-transaction.test.ts`
I am assuming that you want me to leave this function that does a comparison with room for error for the numbers. Just change the function to compare to an essential eth expected result that I hardcode instead of ethers and web transaction objects. Is this what you would like to see here?
Here is your function for reference:
https://github.com/dawsbot/essential-eth/blob/9d8c86c26e89648b3a0f8b1b7d33eca3b0f9a870/src/providers/test/json-rpc-provider/get-transaction.test.ts#L12-L95

