### PR TITLE
🧼 cleaning out ethers from `utils/tests/bytes`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,12 +7,12 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  codecov:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: ['16']
+        node-version: ['18']
 
     steps:
       - uses: actions/checkout@v3
@@ -22,6 +22,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci --ignore-scripts
-      - run: npm run jest -- --coverage
+      - name: 🧪 Codecov test
+        run: npm run jest -- --coverage
+        env:
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['18', '16', '14', '12']
+        node-version: ['20', '18', '16', '14', '12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - '14'
-  - '12'
-  - '10'

--- a/src/utils/tests/bytes/arrayify.test.ts
+++ b/src/utils/tests/bytes/arrayify.test.ts
@@ -1,28 +1,28 @@
-import * as ethers from 'ethers';
 import { arrayify, tinyBig } from '../../..';
 
 describe('arrayify', () => {
-  it('matches ethers', () => {
-    const inputs = [0, 1, '0x1234', new Uint8Array(2), tinyBig(17)];
+  it('should correctly arrayify - values', () => {
+    const testCases = [
+      { input: 0, expected: new Uint8Array([0]) },
+      { input: 1, expected: new Uint8Array([1]) },
+      { input: '0x1234', expected: new Uint8Array([18, 52]) },
+      { input: new Uint8Array(2), expected: new Uint8Array(2) },
+      { input: tinyBig(17), expected: new Uint8Array([17]) }
+    ];
 
-    inputs.forEach((input) => {
-      //       console.log({ input, arr: arrayify(input as any) });
-      expect(arrayify(input)).toStrictEqual(ethers.utils.arrayify(input));
+    testCases.forEach((testCase) => {
+      expect(arrayify(testCase.input)).toStrictEqual(testCase.expected);
     });
-    expect(arrayify('12', { allowMissingPrefix: true })).toStrictEqual(
-      ethers.utils.arrayify('12', { allowMissingPrefix: true }),
-    );
+  });
 
-    expect(arrayify('0x1', { hexPad: 'left' })).toStrictEqual(
-      ethers.utils.arrayify('0x1', { hexPad: 'left' }),
-    );
-    expect(arrayify('0x1', { hexPad: 'right' })).toStrictEqual(
-      ethers.utils.arrayify('0x1', { hexPad: 'right' }),
-    );
+  it('should correctly arrayify - values with options', () => {
+    expect(arrayify('12', { allowMissingPrefix: true })).toStrictEqual(new Uint8Array([18]));
+    expect(arrayify('0x1', { hexPad: 'left' })).toStrictEqual(new Uint8Array([1]));
+    expect(arrayify('0x1', { hexPad: 'right' })).toStrictEqual(new Uint8Array([16]));
+  });
 
-    // hex data is odd length
-    expect(() => arrayify(tinyBig(15))).toThrow();
-    // invalid arrayify value
-    expect(() => arrayify(false as any)).toThrow();
+  it('should throw for invalid values', () => {
+    expect(() => arrayify(tinyBig(15))).toThrow(); // hex data is odd-length
+    expect(() => arrayify(false as any)).toThrow(); // invalid arrayify value
   });
 });

--- a/src/utils/tests/bytes/concat.test.ts
+++ b/src/utils/tests/bytes/concat.test.ts
@@ -1,13 +1,12 @@
-import * as ethers from 'ethers';
 import type { BytesLikeWithNumber } from '../../..';
 import { concat } from '../../..';
 
 describe('concat', () => {
-  it('matches ethers', () => {
+  it('matches expected result', () => {
     const inputs: ReadonlyArray<BytesLikeWithNumber[]> = [[0, 1]];
 
     inputs.forEach((input) => {
-      expect(concat(input)).toStrictEqual(ethers.utils.concat(input as any));
+      expect(concat(input)).toStrictEqual(new Uint8Array([0, 1]));
     });
   });
 });

--- a/src/utils/tests/bytes/hex-concat.test.ts
+++ b/src/utils/tests/bytes/hex-concat.test.ts
@@ -1,20 +1,21 @@
-import { utils as ethers } from 'ethers';
 import { hexConcat } from '../../bytes';
 
 describe('utils.hexConcat', () => {
-  it('should match ethers.js - hex values', () => {
+  it('should correctly concatenate - hex values', () => {
     const values = ['0x2048', '0x6917', '0x85616379'];
-    expect(hexConcat(values)).toBe(ethers.hexConcat(values));
+    const expected = '0x2048691785616379';
+    expect(hexConcat(values)).toBe(expected);
   });
-  it('should match ethers.js - UInt8Array values', () => {
+  it('should correctly concatenate - UInt8Array values', () => {
     const values = [
-      [5, 10, 247, 22],
-      [50, 255, 3],
-      [59, 36, 18, 46, 198, 234],
+      new Uint8Array([5, 10, 247, 22]),
+      new Uint8Array([50, 255, 3]),
+      new Uint8Array([59, 36, 18, 46, 198, 234]),
     ];
-    expect(hexConcat(values)).toBe(ethers.hexConcat(values));
+    const expected = '0x050af71632ff033b24122ec6ea';
+    expect(hexConcat(values)).toStrictEqual(expected);
   });
-  it('should match ethers.js - hex & UInt8Array values', () => {
+  it('should correctly concatenate - hex & UInt8Array values', () => {
     const values = [
       '0x2048',
       [5, 10, 247, 22],
@@ -23,6 +24,7 @@ describe('utils.hexConcat', () => {
       '0x85616379',
       [59, 36, 18, 46, 198, 234],
     ];
-    expect(hexConcat(values)).toBe(ethers.hexConcat(values));
+    const expected = '0x2048050af716691732ff03856163793b24122ec6ea';
+    expect(hexConcat(values)).toStrictEqual(expected);
   });
 });

--- a/src/utils/tests/bytes/hex-data-length.test.ts
+++ b/src/utils/tests/bytes/hex-data-length.test.ts
@@ -1,24 +1,29 @@
-import { utils as ethers } from 'ethers';
 import { hexDataLength } from '../../bytes';
 
 describe('utils.hexDataLength', () => {
-  it('should match ethers.js - hex values', () => {
-    const values = ['0x9347', '0x185754', '0x00005823'];
-    values.forEach((value) => {
-      expect(hexDataLength(value)).toBe(ethers.hexDataLength(value));
-    });
-  });
-  it('should match ethers.js - UInt8Array values', () => {
-    const values = [
-      [9, 58, 29, 24],
-      [185, 203],
-      [239, 30, 49, 41, 5, 10, 42],
+  it('should match expected value - hex values', () => {
+    const testCases = [
+      { value: '0x9347', expected: 2 },
+      { value: '0x185754', expected: 3 },
+      { value: '0x00005823', expected: 4 },
     ];
-    values.forEach((value) => {
-      expect(hexDataLength(value)).toBe(ethers.hexDataLength(value));
+    testCases.forEach((testCase) => {
+      expect(hexDataLength(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
-  it('should return null - not hex value or not divisible by 2', () => {
+
+  it('should match expected value - UInt8Array values', () => {
+    const testCases = [
+      { value: new Uint8Array([9, 58, 29, 24]), expected: 4 },
+      { value: new Uint8Array([185, 203]), expected: 2 },
+      { value: new Uint8Array([239, 30, 49, 41, 5, 10, 42]), expected: 7 },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexDataLength(testCase.value)).toStrictEqual(testCase.expected);
+    });
+  });
+
+  it('should return null  - non-hex values or hex values not divisible by 2', () => {
     const values = ['0x383', 'non-hex string'];
     values.forEach((value) => {
       expect(hexDataLength(value)).toBeNull();

--- a/src/utils/tests/bytes/hex-data-slice.test.ts
+++ b/src/utils/tests/bytes/hex-data-slice.test.ts
@@ -1,38 +1,30 @@
-import { utils as ethers } from 'ethers';
 import { hexDataSlice } from '../../bytes';
 
 describe('utils.hexDataSlice', () => {
-  it('numbers - matches ethers strings', () => {
-    const decimalValues = ['0x123456'];
-    decimalValues.forEach((decimalValue) => {
-      expect(hexDataSlice(decimalValue, 0, 2)).toStrictEqual(
-        ethers.hexDataSlice(decimalValue, 0, 2),
-      );
+  it('should match expected slice - hexadecimal strings', () => {
+    const hexValues = ['0x123456'];
+    hexValues.forEach((hexValue) => {
+      expect(hexDataSlice(hexValue, 0, 2)).toStrictEqual('0x1234');
     });
   });
-  it('numbers - matches ethers hex numbers', () => {
-    const decimalValues = [0x1234567891011];
-    decimalValues.forEach((decimalValue) => {
-      expect(hexDataSlice(decimalValue, 3)).toStrictEqual(
-        ethers.hexDataSlice(decimalValue as any, 3),
-      );
-      expect(hexDataSlice(decimalValue, 2, 4)).toStrictEqual(
-        ethers.hexDataSlice(decimalValue as any, 2, 4),
-      );
-      expect(hexDataSlice(decimalValue, 100)).toStrictEqual(
-        ethers.hexDataSlice(decimalValue as any, 100),
-      );
+
+  it('should match expected slice -  hexadecimal numbers', () => {
+    const hexValues = [0x1234567891011];
+    hexValues.forEach((hexValue) => {
+      expect(hexDataSlice(hexValue, 3)).toBe('0x67891011');
+      expect(hexDataSlice(hexValue, 2, 4)).toBe('0x4567');
+      expect(hexDataSlice(hexValue, 100)).toStrictEqual('0x');
     });
   });
-  it('numbers - matches ethers decimals', () => {
-    const decimalValues = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]];
-    decimalValues.forEach((decimalValue) => {
-      expect(hexDataSlice(decimalValue, 1, 2)).toStrictEqual(
-        ethers.hexDataSlice(decimalValue as any, 1, 2),
-      );
+
+  it('should match expected slice - arrays of decimal numbers', () => {
+    const decimalArrays = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]];
+    decimalArrays.forEach((decimalArray) => {
+      expect(hexDataSlice(decimalArray, 1, 2)).toStrictEqual('0x01');
     });
   });
-  it('should throw error - invalid hexData', () => {
+
+  it('should throw error - invalid hex data', () => {
     const values = ['non-hex string', '0x938'];
     values.forEach((value) => {
       expect(() => hexDataSlice(value, 1, 3)).toThrow('invalid hexData');

--- a/src/utils/tests/bytes/hex-data-slice.test.ts
+++ b/src/utils/tests/bytes/hex-data-slice.test.ts
@@ -4,7 +4,7 @@ describe('utils.hexDataSlice', () => {
   it('should match expected slice - hexadecimal strings', () => {
     const hexValues = ['0x123456'];
     hexValues.forEach((hexValue) => {
-      expect(hexDataSlice(hexValue, 0, 2)).toStrictEqual('0x1234');
+      expect(hexDataSlice(hexValue, 0, 2)).toBe('0x1234');
     });
   });
 
@@ -13,14 +13,14 @@ describe('utils.hexDataSlice', () => {
     hexValues.forEach((hexValue) => {
       expect(hexDataSlice(hexValue, 3)).toBe('0x67891011');
       expect(hexDataSlice(hexValue, 2, 4)).toBe('0x4567');
-      expect(hexDataSlice(hexValue, 100)).toStrictEqual('0x');
+      expect(hexDataSlice(hexValue, 100)).toBe('0x');
     });
   });
 
   it('should match expected slice - arrays of decimal numbers', () => {
     const decimalArrays = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]];
     decimalArrays.forEach((decimalArray) => {
-      expect(hexDataSlice(decimalArray, 1, 2)).toStrictEqual('0x01');
+      expect(hexDataSlice(decimalArray, 1, 2)).toBe('0x01');
     });
   });
 

--- a/src/utils/tests/bytes/hex-strip-zeros.test.ts
+++ b/src/utils/tests/bytes/hex-strip-zeros.test.ts
@@ -1,24 +1,27 @@
-import { utils as ethers } from 'ethers';
 import { hexStripZeros } from '../../bytes';
 
 describe('utils.hexStripZeros', () => {
-  it('should match ethers.js - hex values', () => {
-    const values = ['0x00009347', '0x00185754', '0x00000000005823'];
-    values.forEach((value) => {
-      expect(hexStripZeros(value)).toBe(ethers.hexStripZeros(value));
-    });
-  });
-  it('should match ethers.js - UInt8Array values', () => {
-    const values = [
-      [0, 0, 0, 9, 58, 29, 24],
-      [0, 185, 203],
-      [0, 0, 0, 0, 239, 30, 49, 41, 5, 10, 42],
+  it('should correctly strip leading zeros - hex strings', () => {
+    const testCases = [
+      { value: '0x00009347', expected: '0x9347' },
+      { value: '0x00185754', expected: '0x185754' },
+      { value: '0x00000000005823', expected: '0x5823' },
     ];
-    values.forEach((value) => {
-      expect(hexStripZeros(value)).toBe(ethers.hexStripZeros(value));
+    testCases.forEach((testCase) => {
+      expect(hexStripZeros(testCase.value)).toBe(testCase.expected);
     });
   });
-  it('should throw error - invalid hex string', () => {
+  it('should correctly strip leading zeros - byte arrays', () => {
+    const testCases = [
+      { value: new Uint8Array([0, 0, 0, 9, 58, 29, 24]), expected: '0x93a1d18' },
+      { value: new Uint8Array([0, 185, 203]), expected: '0xb9cb' },
+      { value: new Uint8Array([0, 0, 0, 0, 239, 30, 49, 41, 5, 10, 42]), expected: '0xef1e3129050a2a' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexStripZeros(testCase.value)).toBe(testCase.expected);
+    });
+  });
+  it('should throw error - invalid hex strings', () => {
     const values = ['non-hex string'];
     values.forEach((value) => {
       expect(() => hexStripZeros(value)).toThrow('invalid hex string');

--- a/src/utils/tests/bytes/hex-value.test.ts
+++ b/src/utils/tests/bytes/hex-value.test.ts
@@ -1,46 +1,66 @@
-import { utils as ethers } from 'ethers';
 import { hexValue } from '../../bytes';
 import { tinyBig } from './../../../shared/tiny-big/tiny-big';
 
 describe('utils.hexValue', () => {
-  it('should match ethers.js - hex string', () => {
-    const values = ['0x9347', '0x185754', '0x00005823'];
-    values.forEach((value) => {
-      expect(hexValue(value)).toBe(ethers.hexValue(value));
-    });
-  });
-  it('should match ethers.js - UInt8Array', () => {
-    const values = [
-      [4, 50, 2],
-      [231, 49, 40, 70, 19],
-      [10, 68, 20, 98],
+  it('should correctly convert - hex string', () => {
+    const testCases = [
+      { value: '0x9347', expected: '0x9347' },
+      { value: '0x185754', expected: '0x185754' },
+      { value: '0x00005823', expected: '0x5823' },
     ];
-    values.forEach((value) => {
-      expect(hexValue(value)).toBe(ethers.hexValue(value));
+    testCases.forEach((testCase) => {
+      expect(hexValue(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
-  it('should match ethers.js - TinyBig (hexable)', () => {
-    const values = [tinyBig('29389'), tinyBig(2834), tinyBig(402)];
-    values.forEach((value) => {
-      expect(hexValue(value)).toBe(ethers.hexValue(value));
+  it('should correctly convert - byte array', () => {
+    const testCases = [
+      { value: [4, 50, 2], expected: '0x43202' },
+      { value: [231, 49, 40, 70, 19], expected: '0xe731284613' },
+      { value: [10, 68, 20, 98], expected: '0xa441462' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexValue(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
-  it('should match ethers.js - number', () => {
-    const values = [624, 457, 23451];
-    values.forEach((value) => {
-      expect(hexValue(value)).toBe(ethers.hexValue(value));
+  it('should correctly convert - TinyBig instance', () => {
+    const testCases = [
+      { value: tinyBig('29389'), expected: '0x72cd' },
+      { value: tinyBig(2834), expected: '0xb12' },
+      { value: tinyBig(402), expected: '0x192' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexValue(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
-  it('should match ethers.js - BigInt', () => {
-    const values = [BigInt(204), BigInt('23491'), BigInt(4183459235723491)];
-    values.forEach((value) => {
-      expect(hexValue(value)).toBe(ethers.hexValue(value));
+  it('should correctly convert - number', () => {
+    const testCases = [
+      { value: 624, expected: '0x270' },
+      { value: 457, expected: '0x1c9' },
+      { value: 23451, expected: '0x5b9b' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexValue(testCase.value)).toStrictEqual(testCase.expected);
+    });
+  });
+  it('should correctly convert - BigInt', () => {
+    const testCases = [
+      { value: BigInt(204), expected: '0xcc' },
+      { value: BigInt('23491'), expected: '0x5bc3' },
+      { value: BigInt(4183459235723491), expected: '0xedcd581ad78e3' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexValue(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
   it('should return 0x0 - only zero data given', () => {
-    const values = [BigInt(0), 0, '0x0000', [0, 0, 0]];
-    values.forEach((value) => {
-      expect(hexValue(value)).toBe('0x0');
+    const testCases = [
+      { value: BigInt(0), expected: '0x0' },
+      { value: 0, expected: '0x0' },
+      { value: '0x0000', expected: '0x0' },
+      { value: [0, 0, 0], expected: '0x0' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexValue(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
 });

--- a/src/utils/tests/bytes/hex-zero-pad.test.ts
+++ b/src/utils/tests/bytes/hex-zero-pad.test.ts
@@ -1,52 +1,50 @@
-import * as ethers from 'ethers';
 import { hexZeroPad } from '../../../';
 
 describe('hexZeroPad', () => {
-  it('numbers - matches ethers', () => {
-    const decimalValues = [123, 0];
-    decimalValues.forEach((decimalValue) => {
-      expect(hexZeroPad(decimalValue, 30)).toStrictEqual(
-        ethers.utils.hexZeroPad(decimalValue as any, 30),
-      );
+  it('should correctly pad - numbers', () => {
+    const testCases = [
+      { value: 123, expected: '0x000000000000000000000000000000000000007b' },
+      { value: 0, expected: '0x0000000000000000000000000000000000000000' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexZeroPad(testCase.value, 20)).toStrictEqual(testCase.expected);
     });
   });
-  it('arrays of numbers - matches ethers', () => {
-    const decimalValues = [[1, 2, 3, 4]];
-    decimalValues.forEach((decimalValue) => {
-      expect(hexZeroPad(decimalValue, 30)).toStrictEqual(
-        ethers.utils.hexZeroPad(decimalValue, 30),
-      );
+  it('should correctly pad - arrays of numbers', () => {
+    const testCases = [
+      { value: [1, 2, 3, 4], expected: '0x000000000000000000000001020304' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexZeroPad(testCase.value, 15)).toStrictEqual(testCase.expected);
     });
   });
-  it('should reject strings passed in which are not hex strings', () => {
+  it('should throw error - non-hex string', () => {
     const value = '52908';
     expect(() => {
       hexZeroPad(value, 23);
     }).toThrow();
   });
-  it('should throw error when value is already longer than desired length', () => {
+  it('should throw error - values longer than desired length', () => {
     const hexValues = [0x123456, '0x5aAebAd', '0xfB691', '0xD1220ab'];
     hexValues.forEach((hexValue) => {
       expect(() => hexZeroPad(hexValue, 2)).toThrow();
     });
   });
-  it('should match ethers.js when padding can be applied', () => {
-    const values = [
-      10,
-      '0x5290',
-      '0x8617E3',
-      '0xde709f210',
-      '0x27b',
-      0x0,
-      0x5aaeb605,
-      '0xfB6916095ca1df',
-      '0xdbF03B407c01E7cD3CBea99509d93',
-      0xd1220a0cf4,
+  it('should correctly pad - valid hex values', () => {
+    const testCases = [
+      { value: 10, expected: '0x00000000000000000000000000000a' },
+      { value: '0x5290', expected: '0x000000000000000000000000005290' },
+      { value: '0x8617E3', expected: '0x0000000000000000000000008617E3' },
+      { value: '0xde709f210', expected: '0x000000000000000000000de709f210' },
+      { value: '0x27b', expected: '0x00000000000000000000000000027b' },
+      { value: 0x0, expected: '0x000000000000000000000000000000' },
+      { value: 0x5aaeb605, expected: '0x00000000000000000000005aaeb605' },
+      { value: '0xfB6916095ca1df', expected: '0x0000000000000000fB6916095ca1df' },
+      { value: '0xdbF03B407c01E7cD3CBea99509d93', expected: '0x0dbF03B407c01E7cD3CBea99509d93' },
+      { value: 0xd1220a0cf4, expected: '0x00000000000000000000d1220a0cf4' },
     ];
-    values.forEach((value) => {
-      expect(hexZeroPad(value, 30)).toStrictEqual(
-        ethers.utils.hexZeroPad(value as any, 30),
-      );
+    testCases.forEach((testCase) => {
+      expect(hexZeroPad(testCase.value, 15)).toStrictEqual(testCase.expected);
     });
   });
 });

--- a/src/utils/tests/bytes/hexlify.test.ts
+++ b/src/utils/tests/bytes/hexlify.test.ts
@@ -1,3 +1,4 @@
+import type { DataOptions } from '../../bytes';
 import { hexlify } from '../../bytes';
 import type { BytesLike } from './../../bytes';
 
@@ -17,12 +18,24 @@ describe('utils.hexlify', () => {
     });
   });
   it('should hexlify with options - hexPad', () => {
-    const testCases = [
-      { value: '0x3342e95', options: { hexPad: 'left' }, expected: '0x03342e95' },
-      { value: '0x41c942c42', options: { hexPad: 'right' }, expected: '0x41c942c420' },
+    const testCases: Array<{
+      value: string;
+      options: DataOptions;
+      expected: string;
+    }> = [
+      {
+        value: '0x3342e95',
+        options: { hexPad: 'left' },
+        expected: '0x03342e95',
+      },
+      {
+        value: '0x41c942c42',
+        options: { hexPad: 'right' },
+        expected: '0x41c942c420',
+      },
     ];
     testCases.forEach((testCase) => {
-      expect(hexlify(testCase.value, testCase.options as any)).toBe(testCase.expected);
+      expect(hexlify(testCase.value, testCase.options)).toBe(testCase.expected);
     });
   });
   it('should throw error - hex data is odd-length', () => {
@@ -32,9 +45,10 @@ describe('utils.hexlify', () => {
     });
   });
   it('should throw error - invalid hexlify value', () => {
-    const values = ['non-hex string', false];
+    // @ts-expect-error
+    const values: Array<BytesLike> = ['non-hex string', false];
     values.forEach((value) => {
-      expect(() => hexlify(value as BytesLike)).toThrow('invalid hexlify value');
+      expect(() => hexlify(value)).toThrow('invalid hexlify value');
     });
   });
 });

--- a/src/utils/tests/bytes/hexlify.test.ts
+++ b/src/utils/tests/bytes/hexlify.test.ts
@@ -1,26 +1,28 @@
-import { utils as ethers } from 'ethers';
 import { hexlify } from '../../bytes';
 import type { BytesLike } from './../../bytes';
 
 describe('utils.hexlify', () => {
-  it('numbers - matches ethers strings', () => {
-    const decimalValues = [0, 4, 5, 16, BigInt(0), BigInt(16)];
-    decimalValues.forEach((decimalValue) => {
-      expect(hexlify(decimalValue)).toBe(ethers.hexlify(decimalValue));
-    });
-
-    const opts = { allowMissingPrefix: true };
-    expect(hexlify('22', opts)).toBe(ethers.hexlify('22', opts));
-  });
-  it('should match ethers.js - hexPad options', () => {
-    const values = [
-      ['0x3342e95', { hexPad: 'left' }],
-      ['0x41c942c42', { hexPad: 'right' }],
+  it('matches expected strings - numbers', () => {
+    const testCases = [
+      { value: 0, expected: '0x00' },
+      { value: 4, expected: '0x04' },
+      { value: 5, expected: '0x05' },
+      { value: 16, expected: '0x10' },
+      { value: BigInt(0), expected: '0x00' },
+      { value: BigInt(16), expected: '0x10' },
     ];
-    values.forEach((value) => {
-      expect(hexlify(value[0] as any, value[1] as any)).toBe(
-        ethers.hexlify(value[0] as any, value[1] as any),
-      );
+
+    testCases.forEach((testCase) => {
+      expect(hexlify(testCase.value)).toBe(testCase.expected);
+    });
+  });
+  it('should hexlify with options - hexPad', () => {
+    const testCases = [
+      { value: '0x3342e95', options: { hexPad: 'left' }, expected: '0x03342e95' },
+      { value: '0x41c942c42', options: { hexPad: 'right' }, expected: '0x41c942c420' },
+    ];
+    testCases.forEach((testCase) => {
+      expect(hexlify(testCase.value, testCase.options as any)).toBe(testCase.expected);
     });
   });
   it('should throw error - hex data is odd-length', () => {
@@ -32,9 +34,7 @@ describe('utils.hexlify', () => {
   it('should throw error - invalid hexlify value', () => {
     const values = ['non-hex string', false];
     values.forEach((value) => {
-      expect(() => hexlify(value as BytesLike)).toThrow(
-        'invalid hexlify value',
-      );
+      expect(() => hexlify(value as BytesLike)).toThrow('invalid hexlify value');
     });
   });
 });

--- a/src/utils/tests/bytes/is-bytes-like.test.ts
+++ b/src/utils/tests/bytes/is-bytes-like.test.ts
@@ -1,39 +1,38 @@
-import { utils as ethers } from 'ethers';
 import { isBytesLike } from '../../bytes';
 
 describe('utils.isBytesLike', () => {
-  it('should match ethers.js - hex string', () => {
+  it('should return true - hex string', () => {
     const values = ['0x9347', '0x185754', '0x00005823'];
     values.forEach((value) => {
-      expect(isBytesLike(value)).toBe(ethers.isBytesLike(value));
+      expect(isBytesLike(value)).toBe(true);
     });
   });
-  it('should match ethers.js - UInt8Array', () => {
+  it('should return true - UInt8Array', () => {
     const values = [
       [9, 58, 29, 24],
       [185, 203],
       [239, 30, 49, 41, 5, 10, 42],
     ];
     values.forEach((value) => {
-      expect(isBytesLike(value)).toBe(ethers.isBytesLike(value));
+      expect(isBytesLike(value)).toBe(true);
     });
   });
-  it('should match ethers.js - number', () => {
+  it('should return false - number', () => {
     const values = [152, 513, 2354];
     values.forEach((value) => {
-      expect(isBytesLike(value)).toBe(ethers.isBytesLike(value));
+      expect(isBytesLike(value)).toBe(false);
     });
   });
-  it('should match ethers.js - non-hex string', () => {
+  it('should return false - non-hex string', () => {
     const values = ['essential-eth', 'ethers.js', 'ethereum'];
     values.forEach((value) => {
-      expect(isBytesLike(value)).toBe(ethers.isBytesLike(value));
+      expect(isBytesLike(value)).toBe(false);
     });
   });
-  it('should match ethers.js - boolean', () => {
+  it('should return false - boolean', () => {
     const values = [false, true];
     values.forEach((value) => {
-      expect(isBytesLike(value)).toBe(ethers.isBytesLike(value));
+      expect(isBytesLike(value)).toBe(false);
     });
   });
 });

--- a/src/utils/tests/bytes/is-bytes.test.ts
+++ b/src/utils/tests/bytes/is-bytes.test.ts
@@ -1,25 +1,24 @@
-import * as ethers from 'ethers';
 import { isBytes, isBytesLike } from '../../..';
 
 describe('isBytesLike', () => {
-  it('matches ethers', () => {
-    const inputs = [
-      ['1', '2', '3'],
-      [1, 2, 3],
-      '0x123',
-      123,
-      0x123,
-      'bad',
-      false,
-      { test: 'bad' },
-      null,
-      new Uint8Array(),
-      new Uint8Array(1),
+  it('matches expected', () => {
+    const testCases = [
+      { value: ['1', '2', '3'], isBytesLike: false, isBytes: false },
+      { value: [1, 2, 3], isBytesLike: true, isBytes: true },
+      { value: '0x123', isBytesLike: false, isBytes: false },
+      { value: 123, isBytesLike: false, isBytes: false },
+      { value: 0x123, isBytesLike: false, isBytes: false },
+      { value: 'bad', isBytesLike: false, isBytes: false },
+      { value: false, isBytesLike: false, isBytes: false },
+      { value: { test: 'bad' }, isBytesLike: false, isBytes: false },
+      { value: null, isBytesLike: false, isBytes: false },
+      { value: new Uint8Array(), isBytesLike: true, isBytes: true },
+      { value: new Uint8Array(1), isBytesLike: true, isBytes: true },
     ];
 
-    inputs.forEach((input) => {
-      expect(isBytesLike(input)).toBe(ethers.utils.isBytesLike(input));
-      expect(isBytes(input)).toBe(ethers.utils.isBytes(input));
+    testCases.forEach((testCase) => {
+      expect(isBytesLike(testCase.value)).toBe(testCase.isBytesLike);
+      expect(isBytes(testCase.value)).toBe(testCase.isBytes);
     });
   });
 });

--- a/src/utils/tests/bytes/is-hex-string.test.ts
+++ b/src/utils/tests/bytes/is-hex-string.test.ts
@@ -1,51 +1,49 @@
-import { utils as ethers } from 'ethers';
 import { isHexString } from '../../bytes';
 
 describe('utils.isHexString', () => {
-  it('should match ethers.js - hex string', () => {
+  it('should return true - hex string', () => {
     const values = ['0x9347', '0x185754', '0x00005823'];
     values.forEach((value) => {
-      expect(isHexString(value)).toBe(ethers.isHexString(value));
+      expect(isHexString(value)).toBe(true);
     });
   });
-  it('should match ethers.js - hex string of specific length', () => {
-    const values = [
-      ['0x9347', 2],
-      ['0x185754', 5],
-      ['0x00005823', 4],
+  it('should match expected result- hex string of specific length', () => {
+    const testCases = [
+      { value: ['0x9347', 2], expected: true },
+      // False because '0x185754' is 3 bytes long, not 5.
+      { value: ['0x185754', 5], expected: false },
+      { value: ['0x00005823', 4], expected: true },
     ];
-    values.forEach((value) => {
-      expect(isHexString(value[0], value[1] as number)).toBe(
-        ethers.isHexString(value[0], value[1] as number),
-      );
+    testCases.forEach((testCase) => {
+      expect(isHexString(testCase.value[0], testCase.value[1] as number)).toBe(testCase.expected);
     });
   });
-  it('should match ethers.js - UInt8Array', () => {
+  it('should return false - UInt8Array', () => {
     const values = [
       [9, 58, 29, 24],
       [185, 203],
       [239, 30, 49, 41, 5, 10, 42],
     ];
     values.forEach((value) => {
-      expect(isHexString(value)).toBe(ethers.isHexString(value));
+      expect(isHexString(value)).toBe(false);
     });
   });
-  it('should match ethers.js - number', () => {
+  it('should return false - number', () => {
     const values = [152, 513, 2354];
     values.forEach((value) => {
-      expect(isHexString(value)).toBe(ethers.isHexString(value));
+      expect(isHexString(value)).toBe(false);
     });
   });
-  it('should match ethers.js - non-hex string', () => {
-    const values = ['essential-eth', 'ethers.js', 'ethereum'];
+  it('should return false - non-hex string', () => {
+    const values = ['essential-eth', 'ethers.js', '👋 firek.eth was here hehe'];
     values.forEach((value) => {
-      expect(isHexString(value)).toBe(ethers.isHexString(value));
+      expect(isHexString(value)).toBe(false);
     });
   });
-  it('should match ethers.js - boolean', () => {
+  it('should return false - boolean', () => {
     const values = [false, true];
     values.forEach((value) => {
-      expect(isHexString(value)).toBe(ethers.isHexString(value));
+      expect(isHexString(value)).toBe(false);
     });
   });
 });

--- a/src/utils/tests/bytes/is-hex-string.test.ts
+++ b/src/utils/tests/bytes/is-hex-string.test.ts
@@ -13,9 +13,11 @@ describe('utils.isHexString', () => {
       // False because '0x185754' is 3 bytes long, not 5.
       { value: ['0x185754', 5], expected: false },
       { value: ['0x00005823', 4], expected: true },
-    ];
+    ] as const;
     testCases.forEach((testCase) => {
-      expect(isHexString(testCase.value[0], testCase.value[1] as number)).toBe(testCase.expected);
+      expect(isHexString(testCase.value[0], testCase.value[1])).toBe(
+        testCase.expected,
+      );
     });
   });
   it('should return false - UInt8Array', () => {

--- a/src/utils/tests/bytes/strip-zeros.test.ts
+++ b/src/utils/tests/bytes/strip-zeros.test.ts
@@ -1,27 +1,33 @@
-import { utils as ethers } from 'ethers';
 import { stripZeros } from '../../bytes';
 
 describe('utils.stripZeros', () => {
-  it('should match ethers.js - hex string', () => {
-    const values = ['0x00009347', '0x00185754', '0x00000000005823'];
-    values.forEach((value) => {
-      expect(stripZeros(value)).toStrictEqual(ethers.stripZeros(value));
-    });
-  });
-  it('should match ethers.js - UInt8Array', () => {
-    const values = [
-      [0, 0, 0, 9, 58, 29, 24],
-      [0, 185, 203],
-      [0, 0, 0, 0, 239, 30, 49, 41, 5, 10, 42],
+  it('should match expected result - hex string', () => {
+    const testCases = [
+      { value: '0x00009347', expected: new Uint8Array([147, 71]) },
+      { value: '0x00185754', expected: new Uint8Array([24, 87, 84]) },
+      { value: '0x00000000005823', expected: new Uint8Array([88, 35]) },
     ];
-    values.forEach((value) => {
-      expect(stripZeros(value)).toStrictEqual(ethers.stripZeros(value));
+    testCases.forEach((testCase) => {
+      expect(stripZeros(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
-  it('should match ethers.js - empty array', () => {
-    const values = [[], '0x'];
-    values.forEach((value) => {
-      expect(stripZeros(value)).toStrictEqual(ethers.stripZeros(value));
+  it('should match expected result - UInt8Array', () => {
+    const testCases = [
+      { value: [0, 0, 0, 9, 58, 29, 24], expected: new Uint8Array([9, 58, 29, 24]) },
+      { value: [0, 185, 203], expected: new Uint8Array([185, 203]) },
+      { value: [0, 0, 0, 0, 239, 30, 49, 41, 5, 10, 42], expected: new Uint8Array([239, 30, 49, 41, 5, 10, 42]) },
+    ];
+    testCases.forEach((testCase) => {
+      expect(stripZeros(testCase.value)).toStrictEqual(testCase.expected);
+    });
+  });
+  it('should match expected result - empty array', () => {
+    const testCases = [
+      { value: [], expected: new Uint8Array([]) },
+      { value: '0x', expected: new Uint8Array([]) },
+    ];
+    testCases.forEach((testCase) => {
+      expect(stripZeros(testCase.value)).toStrictEqual(testCase.expected);
     });
   });
 });

--- a/src/utils/tests/bytes/zero-pad.test.ts
+++ b/src/utils/tests/bytes/zero-pad.test.ts
@@ -1,40 +1,49 @@
 import { zeroPad } from '../../bytes';
-import type { BytesLike } from './../../bytes';
 
 describe('utils.zeroPad', () => {
   it('should match expected result - hex string', () => {
     const testCases = [
-      { value: ['0x9347', 10], expected: new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 147, 71]) },
+      {
+        value: ['0x9347', 10],
+        expected: new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 147, 71]),
+      },
       { value: ['0x185754', 5], expected: new Uint8Array([0, 0, 24, 87, 84]) },
-      { value: ['0x00005823', 7], expected: new Uint8Array([0, 0, 0, 0, 0, 88, 35]) },
-    ];
+      {
+        value: ['0x00005823', 7],
+        expected: new Uint8Array([0, 0, 0, 0, 0, 88, 35]),
+      },
+    ] as const;
     testCases.forEach((testCase) => {
-      expect(zeroPad(testCase.value[0] as string, testCase.value[1] as number)).toStrictEqual(
+      expect(zeroPad(testCase.value[0], testCase.value[1])).toStrictEqual(
         testCase.expected,
       );
     });
   });
   it('should match expected result - UInt8Array', () => {
     const testCases = [
-      { value: [[9, 58, 29, 24], 5], expected: new Uint8Array([0, 9, 58, 29, 24]) },
+      {
+        value: [[9, 58, 29, 24], 5],
+        expected: new Uint8Array([0, 9, 58, 29, 24]),
+      },
       { value: [[185, 203], 4], expected: new Uint8Array([0, 0, 185, 203]) },
-      { value: [[239, 30, 49, 41, 5, 10, 42], 10], expected: new Uint8Array([0, 0, 0, 239, 30, 49, 41, 5, 10, 42]) },
-    ];
+      {
+        value: [[239, 30, 49, 41, 5, 10, 42], 10],
+        expected: new Uint8Array([0, 0, 0, 239, 30, 49, 41, 5, 10, 42]),
+      },
+    ] as const;
     testCases.forEach((testCase) => {
-      expect(zeroPad(testCase.value[0] as BytesLike, testCase.value[1] as number)).toStrictEqual(
+      expect(zeroPad(testCase.value[0], testCase.value[1])).toStrictEqual(
         testCase.expected,
       );
     });
-  });  
+  });
   it('should throw error - value out of range', () => {
     const values = [
       [[9, 58, 29, 24], 3],
       ['0x185754', 1],
-    ];
+    ] as const;
     values.forEach((value) => {
-      expect(() => zeroPad(value[0] as BytesLike, value[1] as number)).toThrow(
-        'value out of range',
-      );
+      expect(() => zeroPad(value[0], value[1])).toThrow('value out of range');
     });
   });
 });

--- a/src/utils/tests/bytes/zero-pad.test.ts
+++ b/src/utils/tests/bytes/zero-pad.test.ts
@@ -1,32 +1,31 @@
-import { utils as ethers } from 'ethers';
 import { zeroPad } from '../../bytes';
 import type { BytesLike } from './../../bytes';
 
 describe('utils.zeroPad', () => {
-  it('should match ethers.js - hex string', () => {
-    const values = [
-      ['0x9347', 10],
-      ['0x185754', 5],
-      ['0x00005823', 7],
+  it('should match expected result - hex string', () => {
+    const testCases = [
+      { value: ['0x9347', 10], expected: new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 147, 71]) },
+      { value: ['0x185754', 5], expected: new Uint8Array([0, 0, 24, 87, 84]) },
+      { value: ['0x00005823', 7], expected: new Uint8Array([0, 0, 0, 0, 0, 88, 35]) },
     ];
-    values.forEach((value) => {
-      expect(zeroPad(value[0] as string, value[1] as number)).toStrictEqual(
-        ethers.zeroPad(value[0] as string, value[1] as number),
+    testCases.forEach((testCase) => {
+      expect(zeroPad(testCase.value[0] as string, testCase.value[1] as number)).toStrictEqual(
+        testCase.expected,
       );
     });
   });
-  it('should match ethers.js - UInt8Array', () => {
-    const values = [
-      [[9, 58, 29, 24], 5],
-      [[185, 203], 4],
-      [[239, 30, 49, 41, 5, 10, 42], 10],
+  it('should match expected result - UInt8Array', () => {
+    const testCases = [
+      { value: [[9, 58, 29, 24], 5], expected: new Uint8Array([0, 9, 58, 29, 24]) },
+      { value: [[185, 203], 4], expected: new Uint8Array([0, 0, 185, 203]) },
+      { value: [[239, 30, 49, 41, 5, 10, 42], 10], expected: new Uint8Array([0, 0, 0, 239, 30, 49, 41, 5, 10, 42]) },
     ];
-    values.forEach((value) => {
-      expect(zeroPad(value[0] as BytesLike, value[1] as number)).toStrictEqual(
-        ethers.zeroPad(value[0] as BytesLike, value[1] as number),
+    testCases.forEach((testCase) => {
+      expect(zeroPad(testCase.value[0] as BytesLike, testCase.value[1] as number)).toStrictEqual(
+        testCase.expected,
       );
     });
-  });
+  });  
   it('should throw error - value out of range', () => {
     const values = [
       [[9, 58, 29, 24], 3],


### PR DESCRIPTION
@dawsbot ik you like prs to be shorter, but these changes are very simple. I thought it would just be easier to put them in one pr.
![Screen Shot 2023-05-21 at 7 03 34 PM](https://github.com/dawsbot/essential-eth/assets/106350168/c657b00a-c291-4ef8-bf50-76be36cdbbc1)
