### PR TITLE
🐛 doc build that works on my machine

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@
   - 🟣 Polygon
   - 🔴 Optimism
   - 🔵 Arbitrum
-  - [Many more](src/providers/utils/chains-info.ts)
+  - [Many more](https://github.com/dawsbot/essential-eth/tree/master/src/providers/utils/chains-info.ts)
 - 🧪 Strongly tested
 - 🌲 Tree-shaking and no side-effects
 - 🙌 All common JS versions (CommonJS, ESM, & UMD)
@@ -1584,6 +1584,6 @@ Note: In `web3.js`, almost every method or function can be passed a callback. `e
 
 ## Contributing and GitPOAP
 
-We welcome and appreciate all contributions to Essential Eth! If you're interested in helping us improve this library, please read our [Contributing Guidelines](CONTRIBUTING.md) to understand the types of contributions we're looking for and the process of making them.
+We welcome and appreciate all contributions to Essential Eth! If you're interested in helping us improve this library, please read our [Contributing Guidelines](https://github.com/dawsbot/essential-eth/blob/master/CONTRIBUTING.md) to understand the types of contributions we're looking for and the process of making them.
 
-In partnership with GitPOAP, Essential ETH wants to recognize **all** contributors for their contributions toward the growth of this library. More information about GitPOAP can be found on the [Contributing Guidelines](CONTRIBUTING.md#GitPOAP).
+In partnership with GitPOAP, Essential ETH wants to recognize **all** contributors for their contributions toward the growth of this library. More information about GitPOAP can be found on the [Contributing Guidelines](https://github.com/dawsbot/essential-eth/blob/master/CONTRIBUTING.md#GitPOAP).


### PR DESCRIPTION
@dawsbot This build works on my machine just by changing a few relative paths to absolute and running this:

`nvm use 16 && cd docusaurus && npm install && npm run build`

<img width="590" alt="Screen Shot 2023-05-24 at 9 55 41 PM" src="https://github.com/dawsbot/essential-eth/assets/106350168/8526552d-3b1e-45b0-958b-7ec72331e358">
<img width="843" alt="Screen Shot 2023-05-24 at 9 56 49 PM" src="https://github.com/dawsbot/essential-eth/assets/106350168/c8c695c8-09cc-4685-a231-b4760b8851e3">



I am still not sure about the errors that you get on your machine and how to recreate them on mine
https://github.com/dawsbot/essential-eth/pull/225#discussion_r1185468356

The odd things about the errors on your machine I am trying to understand:

-  My build does not even produce the files that are causing the errors on your machine. Your errors are JSX errors produced in files like `docusaurus/docs/api/interfaces/internal_.RPCLog.md` when I just have have files like `docusaurus/docs/api/interfaces/RPCLog.md` that do not have the internal_ prefix 

- My files don't have JSX as they are just markdown files
